### PR TITLE
Feat/window animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "start": "next start"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@t3-oss/env-nextjs": "^0.10.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "geist": "^1.3.1",
+    "gsap": "^3.12.5",
     "lucide-react": "^0.453.0",
     "next": "15.0.3",
     "react": "19.0.0-rc-66855b96-20241106",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      '@gsap/react':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(react@19.0.0-rc-66855b96-20241106)(types-react@19.0.0-rc.1)
@@ -30,6 +33,9 @@ importers:
       geist:
         specifier: ^1.3.1
         version: 1.3.1(next@15.0.3(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106))
+      gsap:
+        specifier: ^3.12.5
+        version: 3.12.5
       lucide-react:
         specifier: ^0.453.0
         version: 0.453.0(react@19.0.0-rc-66855b96-20241106)
@@ -173,6 +179,9 @@ packages:
 
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
+
+  '@gsap/react@2.1.1':
+    resolution: {integrity: sha512-apGPRrmpqxvl1T6Io1KgT8tFU+IuACI6z4zmT7t8+PASserJeLVRFJdSNUFA2Xb/eVkZI1noE8LIrY/w/oJECw==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1230,6 +1239,9 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  gsap@3.12.5:
+    resolution: {integrity: sha512-srBfnk4n+Oe/ZnMIOXt3gT605BX9x5+rh/prT2F1SsNJsU1XuMiP0E2aptW481OnonOGACZWBqseH5Z7csHxhQ==}
+
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
 
@@ -1768,6 +1780,10 @@ packages:
       react: '>=16.3.0'
       react-dom: '>=16.3.0'
 
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   react@19.0.0-rc-66855b96-20241106:
     resolution: {integrity: sha512-klH7xkT71SxRCx4hb1hly5FJB21Hz0ACyxbXYAECEqssUjtJeFUAaI2U1DgJAzkGEnvEm3DkxuBchMC/9K4ipg==}
     engines: {node: '>=0.10.0'}
@@ -2148,6 +2164,11 @@ snapshots:
       react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
 
   '@floating-ui/utils@0.2.8': {}
+
+  '@gsap/react@2.1.1':
+    dependencies:
+      gsap: 3.12.5
+      react: 18.3.1
 
   '@humanfs/core@0.19.1': {}
 
@@ -3298,6 +3319,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  gsap@3.12.5: {}
+
   has-bigints@1.0.2: {}
 
   has-flag@4.0.0: {}
@@ -3752,6 +3775,10 @@ snapshots:
       react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
       react-draggable: 4.4.6(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
       tslib: 2.6.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.0.0-rc-66855b96-20241106: {}
 

--- a/src/components/raptor-os/system/AppWindow/WindowTitleBar.tsx
+++ b/src/components/raptor-os/system/AppWindow/WindowTitleBar.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
-import { X } from 'lucide-react'
+import { Minus, X } from 'lucide-react'
 import Image from 'next/image';
 
 interface Props {
   id: string;
   label: string;
   icon?: string;
-  closeWindow: (id: string) => void;
+  closeWindow: () => void;
+  minimizeWindow: () => void;
   className?: string;
   isFocused: boolean;
 }
@@ -17,6 +18,7 @@ const WindowTitleBar = ({
   icon,
   isFocused,
   closeWindow,
+  minimizeWindow,
   className
 }: Props) => {
   return (
@@ -36,8 +38,12 @@ const WindowTitleBar = ({
         </span>
       </div>
       <div className='h-full flex flex-row items-start justify-end'>
+        <button className='h-full px-4 py-1 transition duration-200 cursor-default hover:bg-white/20 active:bg-white/25'
+          onClick={minimizeWindow}>
+          <Minus size={20} />
+        </button>
         <button className='h-full px-4 py-1 transition duration-200 cursor-default hover:bg-red-500 active:bg-destructive'
-          onClick={() => { closeWindow(id) }}>
+          onClick={closeWindow}>
           <X size={20} />
         </button>
       </div>

--- a/src/components/raptor-os/system/AppWindow/index.tsx
+++ b/src/components/raptor-os/system/AppWindow/index.tsx
@@ -10,6 +10,7 @@ import css from '@/styles/raptor-os/system/AppWindow/AppWindow.module.css';
 
 import { gsap } from "gsap";
 import { useGSAP } from '@gsap/react';
+import { set } from 'zod';
 
 interface Props extends AppWindowType {
   closeWindow: (id: string) => void;
@@ -23,6 +24,8 @@ const Index = (props: Props) => {
   const rndRef = useRef<Rnd | null>(null);
   const animationRef = useRef<HTMLDivElement | null>(null); // Ref for inner div
   const [currentZIndex, setCurrentZIndex] = useState(props.zIndex);
+
+  const [isClosed, setIsClosed] = useState(false);
 
   const { browserWidth, browserHeight } = useWindowDimensions();
 
@@ -66,17 +69,20 @@ const Index = (props: Props) => {
   }, []);
 
   // GSAP Window close animation
-  const handleCloseWindow = () => {
-    if (animationRef.current) {
+  useGSAP(() => {
+    if (isClosed) {
       gsap.to(animationRef.current, {
         opacity: 0,
         scale: 0.9,
         ease: "power1.out",
         duration: 0.2,
-        onComplete: props.closeWindow,
+        onComplete: () => {
+          props.closeWindow(props.id);
+        },
       });
     }
-  };
+  }, [isClosed]);
+
 
   return (
     <Rnd
@@ -112,7 +118,7 @@ const Index = (props: Props) => {
           label={props.label}
           icon={props.icon}
           id={props.id}
-          closeWindow={handleCloseWindow}
+          closeWindow={() => { setIsClosed(true) }}
           isFocused={props.isFocused}
         />
         {

--- a/src/components/raptor-os/system/AppWindow/index.tsx
+++ b/src/components/raptor-os/system/AppWindow/index.tsx
@@ -24,10 +24,9 @@ interface Props extends AppWindowType {
 const Index = (props: Props) => {
   const rndRef = useRef<Rnd | null>(null);
   const animationRef = useRef<HTMLDivElement | null>(null); // Ref for inner div
+
   const [currentZIndex, setCurrentZIndex] = useState(props.zIndex);
-
   const [isClosed, setIsClosed] = useState(false);
-
   const [wasMinimized, setWasMinimized] = useState(false);
 
   const { browserWidth, browserHeight } = useWindowDimensions();
@@ -123,8 +122,6 @@ const Index = (props: Props) => {
     }
   }, [props.isMinimized, wasMinimized]);
 
-  //if (props.isMinimized) return null; // Resets size and position
-
   return (
     <Rnd
       ref={rndRef}
@@ -147,7 +144,7 @@ const Index = (props: Props) => {
       onMouseDown={props.onFocus}
       style={{
         zIndex: currentZIndex,
-        display: props.isMinimized ? "none" : "block",
+        display: props.isMinimized ? "none" : "block", // Disable the window when minimized
       }}
     >
       <div

--- a/src/components/raptor-os/system/Taskbar/TaskbarIcon.tsx
+++ b/src/components/raptor-os/system/Taskbar/TaskbarIcon.tsx
@@ -52,7 +52,7 @@ const TaskbarIcon = ({ app, openWindow, className }: Props) => {
     } else {
       setIsFocused(false);
     }
-  }, [context.focusedWindowId]);
+  }, [context.focusedWindowId, app.id]);
 
   // If app window is open, set border color
   useEffect(() => {
@@ -61,7 +61,7 @@ const TaskbarIcon = ({ app, openWindow, className }: Props) => {
     } else {
       setAppOpen(false);
     }
-  }, [context.windows]);
+  }, [context.windows, app.id]);
 
   return (
     <TooltipProvider>

--- a/src/components/raptor-os/system/Taskbar/TaskbarIcon.tsx
+++ b/src/components/raptor-os/system/Taskbar/TaskbarIcon.tsx
@@ -1,5 +1,6 @@
-import { type AppWindowType } from '@/context/WindowProvider/window-provider';
-import React from 'react'
+'use client'
+import { useWindowContext, type AppWindowType } from '@/context/WindowProvider/window-provider';
+import React, { useEffect, useRef, useState } from 'react'
 import Image from 'next/image';
 
 type Props = {
@@ -15,8 +16,53 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
+import { gsap } from "gsap";
+import { useGSAP } from '@gsap/react';
+
 
 const TaskbarIcon = ({ app, openWindow, className }: Props) => {
+  const context = useWindowContext();
+  const iconRef = useRef<HTMLImageElement>(null);
+
+  const [isFocused, setIsFocused] = useState(false);
+  const [appOpen, setAppOpen] = useState(false);
+  const [isActive, setActive] = useState(false);
+
+  // GSAP Icon scale animation
+  useGSAP(() => {
+    if (iconRef.current) {
+      if (isActive) {
+        gsap.to(iconRef.current, {
+          scale: 0.8,
+          duration: 0.15,
+        });
+      } else {
+        gsap.to(iconRef.current, {
+          scale: 1,
+          duration: 0.15,
+        });
+      }
+    }
+  }, [isActive]);
+
+  // If app window is focused, set bg color
+  useEffect(() => {
+    if (context.focusedWindowId === app.id) {
+      setIsFocused(true);
+    } else {
+      setIsFocused(false);
+    }
+  }, [context.focusedWindowId]);
+
+  // If app window is open, set border color
+  useEffect(() => {
+    if (context.getWindowById(app.id)) {
+      setAppOpen(true);
+    } else {
+      setAppOpen(false);
+    }
+  }, [context.windows]);
+
   return (
     <TooltipProvider>
       <Tooltip>
@@ -27,18 +73,30 @@ const TaskbarIcon = ({ app, openWindow, className }: Props) => {
           onClick={() => {
             openWindow(app);
           }}
-          className={`w-12 h-12 p-1
-        flex place-items-center
-        rounded-md cursor-default 
-        hover:bg-white/20 
-        active:bg-white/35 
-        select-none transition-all duration-200
-        ${className && className}`}
+          onMouseDown={() => { setActive(true) }}
+          onMouseUp={() => { setActive(false) }}
+          className={`w-14 h-14
+            flex items-center justify-center
+            rounded-md cursor-default border border-transparent
+            
+            ${isFocused && 'bg-white/20'}
+            hover:bg-white/30
+            active:bg-white/45 
+            
+            select-none transition-all duration-200
+            ${className && className}`}
         >
+          <div className={`
+          absolute top-0 md:top-auto md:-left-0  rounded-lg
+          ${appOpen ? 'opacity-100' : 'opacity-0'}
+          ${isFocused ? 'bg-taskbar-icon-window-focused w-8 h-1 md:w-1 md:h-8' : 'w-1.5 h-1.5 bg-white/50'}
+          transition-all duration-200
+            `} />
           <Image
+            ref={iconRef}
             src={app.icon ?? '/img/missing.webp'}
-            width={48}
-            height={48}
+            width={36}
+            height={36}
             alt={app.label}
             draggable={false}
             placeholder='empty'

--- a/src/components/raptor-os/system/Taskbar/index.tsx
+++ b/src/components/raptor-os/system/Taskbar/index.tsx
@@ -18,14 +18,14 @@ const Taskbar = (_props: Props) => {
   return (
     <div className={` static 
       bottom-0      md:left-0 
-      w-screen      md:max-w-20
+      w-screen      md:max-w-[72px]
       h-14          md:h-screen
       flex flex-row md:flex-col 
-      px-2          md:px-0.5
-      py-0.5        md:py-2
+      px-2          md:px-0
+      py-0        md:py-2
       justify-between items-center
       bg-black/15 backdrop-blur
-      shadow-sm md:shadow-xl`}>
+      shadow-sm     md:shadow-xl`}>
       <div className='flex flex-row md:flex-col
       gap-2 items-center justify-start'>
         {appList.map(app =>

--- a/src/components/raptor-os/system/WindowLayer/index.tsx
+++ b/src/components/raptor-os/system/WindowLayer/index.tsx
@@ -10,9 +10,7 @@ const index = (_props: Props) => {
   const context = useWindowContext();
   return (
     <div className='z-10'>
-      {/* List all the apps present in the array.
-        TODO: implement minimizing
-    */}
+      {/* List all the apps present in the array.*/}
       {context.windows.map((window: AppWindowType) => (
         <AppWindow
           key={window.id}
@@ -21,6 +19,8 @@ const index = (_props: Props) => {
           isFocused={context.focusedWindowId === window.id}
           onFocus={() => context.bringToFront(window.id)}
           closeWindow={context.closeWindow}
+          minimizeWindow={context.minimizeWindow}
+          isMinimized={window.isMinimized}
           isDeviceMobile={context.isDeviceMobile}
         />
       ))}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,6 +33,7 @@
       --chart-3: hsl(197 37% 24%);
       --chart-4: hsl(43 74% 66%);
       --chart-5: hsl(27 87% 67%);
+      --taskbar-icon-window-focused: hsl(2 87% 67%);
     }
 
     .dark {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -55,7 +55,8 @@ export default {
 					'3': 'var(--chart-3)',
 					'4': 'var(--chart-4)',
 					'5': 'var(--chart-5)'
-				}
+				},
+				'taskbar-icon-window-focused': 'var(--taskbar-icon-window-focused)',
 			}
 		}
 	},


### PR DESCRIPTION
[Created window animations](https://github.com/Raptor1818/RaptorOS/commit/594ddd47a0bdb7dbad73f1198a096df880052e11)

- Animation on open and on close
- using GSAP Tweens and useGSAP hook
- created new ref for the inner div of the window since Rnd doesn't want to cooperate, moved styles to it

[Fixed opacity not resetting after closing](https://github.com/Raptor1818/RaptorOS/commit/f5550b877f08aaa05c44f6018be0490d48f7dac4)

- Using useGSAP on the close animation to clean up the settings for the animation to run again on startup after closing a window

[Minimize](https://github.com/Raptor1818/RaptorOS/commit/c80cf8b9f67c80774cf7b65875a79b9825cc5b7c)

- Can be minimized, isMinimized set to true when the context function is called.
- Trying to open a window that was minimized, just unminimizes it.
- display: none when minimized, keeping size and position

[Taskbar styles for window states](https://github.com/Raptor1818/RaptorOS/commit/d724401355f27e9381132e08ca89d7129bf0656e)

- Dot appears when app is open and not in focus
- transforms into an orange bar if the app is focused